### PR TITLE
Add free-tier dot type limit and wire billing to client

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,8 @@ import {
   authEmailInput,
   authSendButton,
   authSignOutButton,
+  billingManage,
+  billingUpgrade,
   brandHomeButton,
   colorModeDarkButton,
   colorModeLightButton,
@@ -73,6 +75,7 @@ import {
   shiftYearBy
 } from "./ui.js";
 import {
+  getAccessToken,
   handleMagicLink,
   initSupabaseAuth,
   refreshAuthSession,
@@ -80,6 +83,7 @@ import {
   signOutSupabase,
   updateAuthUI
 } from "./auth.js";
+import { openBillingPortal, startCheckout } from "./billing.js";
 import { showToast } from "./toast.js";
 
 // Wire cross-module callbacks so `state` can request UI work and cloud sync.
@@ -211,6 +215,16 @@ colorModeDarkButton?.addEventListener("click", () => {
   state.darkMode = true;
   saveAndRender();
   showToast("Dark mode on.");
+});
+
+// Billing controls.
+billingUpgrade?.addEventListener("click", async () => {
+  const token = await getAccessToken();
+  startCheckout(token, "monthly");
+});
+billingManage?.addEventListener("click", async () => {
+  const token = await getAccessToken();
+  openBillingPortal(token);
 });
 
 // Export/import controls.

--- a/src/auth.js
+++ b/src/auth.js
@@ -36,6 +36,7 @@ import {
   resetToLoggedOut
 } from "./ui.js";
 import { showToast } from "./toast.js";
+import { fetchBillingStatus, resetBilling } from "./billing.js";
 
 const supabase = window.supabase?.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
@@ -105,6 +106,7 @@ export async function initSupabaseAuth() {
   updateAuthUI();
   if (syncUser) {
     await loadFromCloud({ fromAuthBootstrap: true });
+    fetchBillingStatus(await getAccessToken()).catch(() => {});
     if (shouldFocusTodayOnEntry) {
       focusPeriodToToday();
       clearAuthIntent();
@@ -130,6 +132,7 @@ export async function initSupabaseAuth() {
     updateAuthUI();
     if (syncUser) {
       await loadFromCloud({ fromAuthBootstrap: !wasSignedIn });
+      fetchBillingStatus(await getAccessToken()).catch(() => {});
       if (!wasSignedIn && shouldFocusTodayOnEntry) {
         focusPeriodToToday();
         clearAuthIntent();
@@ -138,6 +141,7 @@ export async function initSupabaseAuth() {
     } else {
       lastSyncError = "";
       stopSyncPolling();
+      resetBilling();
       setState(structuredClone(defaultState));
       requestRender();
       showMarketingPage();
@@ -163,11 +167,18 @@ export async function refreshAuthSession({ loadCloud = false } = {}) {
   updateAuthUI();
   if (syncUser) {
     if (loadCloud) await loadFromCloud({ silentError: true });
+    fetchBillingStatus(await getAccessToken()).catch(() => {});
     startSyncPolling();
   } else {
     stopSyncPolling();
   }
   return syncUser;
+}
+
+export async function getAccessToken() {
+  if (!supabase) return null;
+  const { data } = await supabase.auth.getSession();
+  return data?.session?.access_token || null;
 }
 
 function focusPeriodToToday() {

--- a/src/billing.js
+++ b/src/billing.js
@@ -1,0 +1,142 @@
+import { FREE_DOT_TYPE_LIMIT } from "./constants.js";
+import { billingManage, billingStatus, billingUpgrade } from "./dom.js";
+import { showToast } from "./toast.js";
+
+let cachedIsPro = false;
+let fetchInFlight = null;
+
+/**
+ * Returns true when the current user has an active Pro subscription.
+ * Safe to call frequently — returns cached value synchronously.
+ */
+export function isPro() {
+  return cachedIsPro;
+}
+
+/**
+ * Fetches the billing status from /api/billing/status and caches the result.
+ * Requires a valid Supabase access token. Silently falls back to free tier
+ * on any error so the app never breaks.
+ */
+export async function fetchBillingStatus(accessToken) {
+  if (!accessToken) {
+    cachedIsPro = false;
+    renderBillingUI();
+    return;
+  }
+  if (fetchInFlight) return fetchInFlight;
+  fetchInFlight = (async () => {
+    try {
+      const response = await fetch("/api/billing/status", {
+        headers: { Authorization: `Bearer ${accessToken}` }
+      });
+      if (!response.ok) {
+        cachedIsPro = false;
+        renderBillingUI();
+        return;
+      }
+      const data = await response.json();
+      cachedIsPro = Boolean(data?.isPro);
+    } catch {
+      cachedIsPro = false;
+    } finally {
+      fetchInFlight = null;
+    }
+    renderBillingUI();
+  })();
+  return fetchInFlight;
+}
+
+/**
+ * Resets the cached billing state (used on sign-out).
+ */
+export function resetBilling() {
+  cachedIsPro = false;
+  renderBillingUI();
+}
+
+/**
+ * Returns the maximum number of dot types the user can create.
+ * Pro users get Infinity (unlimited), free users get the configured limit.
+ */
+export function dotTypeLimit() {
+  return cachedIsPro ? Infinity : FREE_DOT_TYPE_LIMIT;
+}
+
+/**
+ * Returns true if the user can add another dot type, given their current count.
+ */
+export function canAddDotType(currentCount) {
+  return currentCount < dotTypeLimit();
+}
+
+/**
+ * Updates the billing section in Settings to reflect current tier.
+ */
+function renderBillingUI() {
+  if (!billingStatus) return;
+  if (cachedIsPro) {
+    billingStatus.textContent = "Pro plan. Unlimited dot types.";
+    if (billingUpgrade) billingUpgrade.classList.add("hidden");
+    if (billingManage) billingManage.classList.remove("hidden");
+  } else {
+    billingStatus.textContent = `Free plan: up to ${FREE_DOT_TYPE_LIMIT} dot types.`;
+    if (billingUpgrade) billingUpgrade.classList.remove("hidden");
+    if (billingManage) billingManage.classList.add("hidden");
+  }
+}
+
+/**
+ * Opens a Stripe Checkout session for the given billing cycle.
+ */
+export async function startCheckout(accessToken, cycle = "monthly") {
+  if (!accessToken) {
+    showToast("Sign in first to upgrade.");
+    return;
+  }
+  try {
+    const response = await fetch("/api/billing/checkout", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ cycle })
+    });
+    const data = await response.json();
+    if (data?.url) {
+      window.location.href = data.url;
+    } else {
+      showToast(data?.error || "Could not start checkout.");
+    }
+  } catch {
+    showToast("Could not start checkout.");
+  }
+}
+
+/**
+ * Opens the Stripe Customer Portal so the user can manage their subscription.
+ */
+export async function openBillingPortal(accessToken) {
+  if (!accessToken) {
+    showToast("Sign in first to manage billing.");
+    return;
+  }
+  try {
+    const response = await fetch("/api/billing/portal", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json"
+      }
+    });
+    const data = await response.json();
+    if (data?.url) {
+      window.location.href = data.url;
+    } else {
+      showToast(data?.error || "Could not open billing portal.");
+    }
+  } catch {
+    showToast("Could not open billing portal.");
+  }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,9 @@ export const SUGGESTED_DOT_TYPES = [
   { name: "Exploring", color: "#6C5CE7" }
 ];
 
+// Free-tier feature limits.
+export const FREE_DOT_TYPE_LIMIT = 6;
+
 // Incremental loading/timing constants used by period picker and modal animations.
 export const YEAR_BATCH_SIZE = 10;
 export const MOBILE_MONTH_BATCH_SIZE = 12;

--- a/src/dom.js
+++ b/src/dom.js
@@ -64,3 +64,6 @@ export const authSignOutButton = document.querySelector("#auth-signout");
 export const authRow = document.querySelector("#auth-row");
 export const settingsBackButton = document.querySelector("#settings-back");
 export const resetOnboardingButton = document.querySelector("#reset-onboarding");
+export const billingStatus = document.querySelector("#billing-status");
+export const billingUpgrade = document.querySelector("#billing-upgrade");
+export const billingManage = document.querySelector("#billing-manage");

--- a/src/ui.js
+++ b/src/ui.js
@@ -7,6 +7,7 @@ import {
   DEV_POLL_MS,
   DEMO_MODE,
   DOT_NAME_MAX_LENGTH,
+  FREE_DOT_TYPE_LIMIT,
   MENU_SCRIM_HIDE_MS,
   MOBILE_BREAKPOINT,
   MOBILE_MONTH_BATCH_SIZE,
@@ -22,6 +23,7 @@ import {
   VIEW_MODE_KEY,
   YEAR_BATCH_SIZE
 } from "./constants.js";
+import { canAddDotType, isPro } from "./billing.js";
 import {
   appShell,
   colorModeDarkButton,
@@ -1074,12 +1076,14 @@ export function renderDotTypeList(targetList = dotTypeList) {
   });
 
   if (targetList === dotTypeList && state.hideSuggestions) {
+    const atLimit = !canAddDotType(state.dotTypes.length);
     const addItem = document.createElement("li");
     addItem.className = "dot-type-add-item";
     const addButton = document.createElement("button");
     addButton.type = "button";
     addButton.className = "suggestion-chip add-new";
-    addButton.textContent = "Add New";
+    addButton.textContent = atLimit ? `Upgrade to add more` : "Add New";
+    addButton.disabled = atLimit;
     addButton.addEventListener("click", addNewDotType);
     addItem.appendChild(addButton);
     targetList.appendChild(addItem);
@@ -1090,12 +1094,14 @@ export function renderSuggestedDotTypes(targetList = suggestedDotList) {
   if (!targetList) return;
   targetList.innerHTML = "";
 
+  const suggestionAtLimit = !canAddDotType(state.dotTypes.length);
   SUGGESTED_DOT_TYPES.forEach((suggestion) => {
     if (hasDotTypeName(suggestion.name)) return;
 
     const chip = document.createElement("button");
     chip.type = "button";
     chip.className = "suggestion-chip";
+    chip.disabled = suggestionAtLimit;
     const chipSwatch = document.createElement("span");
     chipSwatch.className = "swatch";
     chipSwatch.style.background = suggestion.color;
@@ -1106,10 +1112,12 @@ export function renderSuggestedDotTypes(targetList = suggestedDotList) {
     targetList.appendChild(chip);
   });
 
+  const atLimit = !canAddDotType(state.dotTypes.length);
   const addNewChip = document.createElement("button");
   addNewChip.type = "button";
   addNewChip.className = "suggestion-chip add-new";
-  addNewChip.textContent = "Add New";
+  addNewChip.textContent = atLimit ? "Upgrade to add more" : "Add New";
+  addNewChip.disabled = atLimit;
   addNewChip.addEventListener("click", addNewDotType);
   targetList.appendChild(addNewChip);
 }
@@ -1542,6 +1550,10 @@ export function openPeriodMenu() {
 
 export function addSuggestedDotType(suggestion) {
   if (hasDotTypeName(suggestion.name)) return;
+  if (!canAddDotType(state.dotTypes.length)) {
+    showToast(`Free plan allows ${FREE_DOT_TYPE_LIMIT} dot types. Upgrade to Pro for unlimited.`);
+    return;
+  }
   state.dotTypes.push({
     id: crypto.randomUUID(),
     name: suggestion.name,
@@ -1552,6 +1564,10 @@ export function addSuggestedDotType(suggestion) {
 }
 
 export function addNewDotType() {
+  if (!canAddDotType(state.dotTypes.length)) {
+    showToast(`Free plan allows ${FREE_DOT_TYPE_LIMIT} dot types. Upgrade to Pro for unlimited.`);
+    return;
+  }
   const dotId = crypto.randomUUID();
   const dotName = "New Dot";
   state.dotTypes.push({


### PR DESCRIPTION
## Summary
- Free users are now limited to 6 dot types
- Wires existing Stripe billing API endpoints to the client so users can upgrade to Pro for unlimited dot types
- Billing status is fetched on auth and cached in a new billing module; the UI disables add buttons and shows an upgrade prompt when the limit is reached

## Changes
- **src/billing.js** — new module for fetching/caching billing status and managing checkout/portal flows
- **src/app.js** — initialize billing on auth, pass billing state to UI
- **src/auth.js** — expose billing status fetch on login
- **src/ui.js** — disable dot type creation and show upgrade prompt when limit reached
- **src/constants.js** — add `FREE_DOT_TYPE_LIMIT` constant
- **src/dom.js** — add upgrade prompt DOM references

