### PR TITLE
Fix duplicate Privacy Policy/Impressum links on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,10 +117,6 @@
           </div>
         </section>
       </div>
-      <div class="legal-link-row marketing-legal-links legal-link-group">
-        <a href="./privacy.html">Privacy Policy</a>
-        <a href="./impressum.html">Impressum</a>
-      </div>
       </div>
 
       <div class="marketing-card hidden" id="marketing-login">
@@ -143,10 +139,10 @@
         <div class="marketing-actions">
           <button id="login-back" type="button" class="outline-button">Back</button>
         </div>
-        <div class="legal-link-row marketing-legal-links legal-link-group">
-          <a href="./privacy.html">Privacy Policy</a>
-          <a href="./impressum.html">Impressum</a>
-        </div>
+      </div>
+      <div class="legal-link-row marketing-legal-links legal-link-group">
+        <a href="./privacy.html">Privacy Policy</a>
+        <a href="./impressum.html">Impressum</a>
       </div>
     </section>
 


### PR DESCRIPTION
Remove legal links from inside both #marketing-hero and #marketing-login
cards, and place a single instance outside both containers as a sibling
element. This prevents the links from showing twice on mobile when the
login card overlays the hero.

https://claude.ai/code/session_01Xrs7a2fW1TEbhdkxQVekwG