### PR TITLE
Fix settings button not working on mobile after calendar interaction

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -148,7 +148,11 @@ authSignOutButton?.addEventListener("click", signOutSupabase);
 settingsBackButton?.addEventListener("click", closeSettingsModal);
 openSettings?.addEventListener("click", async () => {
   closePopover();
-  await refreshAuthSession({ loadCloud: false });
+  try {
+    await refreshAuthSession({ loadCloud: false });
+  } catch {
+    // Don't let a failed auth check block opening settings.
+  }
   openSettingsModal();
 });
 todayButton?.addEventListener("click", scrollToToday);

--- a/styles.css
+++ b/styles.css
@@ -999,6 +999,7 @@ textarea {
   transform: translateY(-50%);
   display: flex;
   gap: 8px;
+  z-index: 19;
 }
 
 .today-button {

--- a/styles.css
+++ b/styles.css
@@ -3160,11 +3160,12 @@ html[data-theme="dark"] .dot-actions-item:disabled:hover {
   }
 
   .view-nav {
-    position: static;
+    position: relative;
     transform: none;
     gap: 6px;
     flex-shrink: 0;
     align-items: center;
+    z-index: 19;
   }
 
   /* Hide "Settings" text label, keep icon */


### PR DESCRIPTION
On mobile, the topbar moves to the bottom of the screen (order: 2),
placing the settings button in the same area as the popover scrim
(z-index: 18). When a popover is open, the scrim covers the entire
viewport with pointer-events: auto, intercepting all taps before they
reach the settings button. The scrim's pointerdown handler calls
preventDefault/stopPropagation, so the click never reaches the button.

Fix: give .view-nav (containing the settings button) position: relative
and z-index: 19 on mobile. This places it above the scrim (z-18) but
below the popover (z-20), so the button is always tappable while the
popover remains interactive. The topbar itself keeps no z-index to avoid
trapping the period-picker menu in a stacking context.

https://claude.ai/code/session_01MJLrsrfSeFQTEH51ZMBpak